### PR TITLE
Issue#109. [Core] use entry processors for all operations on documents

### DIFF
--- a/bagri-rest/pom.xml
+++ b/bagri-rest/pom.xml
@@ -107,11 +107,6 @@
             <scope>test</scope>
         </dependency>
         <dependency>
-            <groupId>org.glassfish.jersey.core</groupId>
-            <artifactId>jersey-client</artifactId>
-            <scope>test</scope>
-        </dependency>
-        <dependency>
             <groupId>org.glassfish.jersey.test-framework.providers</groupId>
             <artifactId>jersey-test-framework-provider-jetty</artifactId>
             <scope>test</scope>

--- a/bagri-server/bagri-server-hazelcast/src/main/java/com/bagri/server/hazelcast/task/doc/DocumentProcessor.java
+++ b/bagri-server/bagri-server-hazelcast/src/main/java/com/bagri/server/hazelcast/task/doc/DocumentProcessor.java
@@ -4,9 +4,6 @@ import static com.bagri.core.Constants.pn_client_storeMode;
 import static com.bagri.core.Constants.pv_client_storeMode_insert;
 import static com.bagri.core.Constants.pv_client_storeMode_merge;
 import static com.bagri.core.api.TransactionManagement.TX_NO;
-import static com.bagri.core.model.Document.dvFirst;
-import static com.bagri.core.server.api.CacheConstants.PN_XDM_SCHEMA_POOL;
-//import static com.bagri.client.hazelcast.serialize.TaskSerializationFactory.cli_ProcessDocumentTask;
 
 import java.util.Properties;
 import java.util.Map.Entry;
@@ -36,10 +33,10 @@ public class DocumentProcessor implements EntryProcessor<DocumentKey, Document>,
 	private static final long serialVersionUID = 1L;
 
 	private static final transient Logger logger = LoggerFactory.getLogger(DocumentProcessor.class);
-	
+
 	private transient DocumentManagementImpl docMgr;
 	private transient DataDistributionService ddSvc;
-	
+
 	private Transaction tx;
 	private String uri;
 	private Object content;
@@ -63,12 +60,12 @@ public class DocumentProcessor implements EntryProcessor<DocumentKey, Document>,
 		//this.repo = repo;
 		this.docMgr = (DocumentManagementImpl) repo.getDocumentManagement();
 	}
-	
+
     @Autowired
     public void setDistrService(DataDistributionService ddSvc) {
     	this.ddSvc = ddSvc;
     }
-	
+
 	@Override
 	public void processBackup(Entry<DocumentKey, Document> entry) {
 		//this.process(entry);
@@ -84,7 +81,7 @@ public class DocumentProcessor implements EntryProcessor<DocumentKey, Document>,
 		long txStart = tx == null ? TX_NO : tx.getTxId();
 		if (lastKey != null && lastKey.getVersion() > entry.getKey().getVersion()) {
 			if (txStart > TX_NO && tx.getTxIsolation().ordinal() > TransactionIsolation.readCommited.ordinal()) {
-	    		return new BagriException("Document with key: " + entry.getKey() +	", uri: " + uri + 
+	    		return new BagriException("Document with key: " + entry.getKey() +	", uri: " + uri +
 	    				" has been concurrently updated; latest key is: " + lastKey, BagriException.ecDocument);
 			}
 			Document lastDoc = docMgr.getDocument(lastKey);
@@ -126,5 +123,5 @@ public class DocumentProcessor implements EntryProcessor<DocumentKey, Document>,
 	//}
 
 }
-	
+
 

--- a/bagri-server/bagri-server-hazelcast/src/main/java/com/bagri/server/hazelcast/task/doc/DocumentRemoveProcessor.java
+++ b/bagri-server/bagri-server-hazelcast/src/main/java/com/bagri/server/hazelcast/task/doc/DocumentRemoveProcessor.java
@@ -6,7 +6,6 @@ import com.bagri.core.api.TransactionIsolation;
 import com.bagri.core.model.Document;
 import com.bagri.core.model.Transaction;
 import com.bagri.server.hazelcast.impl.DataDistributionService;
-import com.hazelcast.core.IMap;
 import com.hazelcast.core.Offloadable;
 import com.hazelcast.map.EntryBackupProcessor;
 import com.hazelcast.map.EntryProcessor;
@@ -23,11 +22,9 @@ public class DocumentRemoveProcessor implements EntryProcessor<DocumentKey, Docu
 
     private static final long serialVersionUID = 1L;
 
-    private IMap<DocumentKey, Document> xddCache;
     private Transaction tx;
 
-    public DocumentRemoveProcessor(IMap<DocumentKey, Document> xddCache, Transaction tx) {
-        this.xddCache = xddCache;
+    public DocumentRemoveProcessor(Transaction tx) {
         this.tx = tx;
     }
 
@@ -52,7 +49,7 @@ public class DocumentRemoveProcessor implements EntryProcessor<DocumentKey, Docu
         }
 
         doc.finishDocument(txStart);
-        xddCache.set(entry.getKey(), doc);
+        entry.setValue(doc);
         return doc;
     }
 

--- a/bagri-server/bagri-server-hazelcast/src/main/java/com/bagri/server/hazelcast/task/doc/DocumentRemoveProcessor.java
+++ b/bagri-server/bagri-server-hazelcast/src/main/java/com/bagri/server/hazelcast/task/doc/DocumentRemoveProcessor.java
@@ -1,0 +1,68 @@
+package com.bagri.server.hazelcast.task.doc;
+
+import com.bagri.core.DocumentKey;
+import com.bagri.core.api.BagriException;
+import com.bagri.core.api.TransactionIsolation;
+import com.bagri.core.model.Document;
+import com.bagri.core.model.Transaction;
+import com.bagri.server.hazelcast.impl.DataDistributionService;
+import com.hazelcast.core.IMap;
+import com.hazelcast.core.Offloadable;
+import com.hazelcast.map.EntryBackupProcessor;
+import com.hazelcast.map.EntryProcessor;
+import com.hazelcast.spring.context.SpringAware;
+import org.springframework.beans.factory.annotation.Autowired;
+
+import java.util.Map;
+
+import static com.bagri.core.api.TransactionManagement.*;
+
+@SpringAware
+public class DocumentRemoveProcessor implements EntryProcessor<DocumentKey, Document>, EntryBackupProcessor<DocumentKey, Document>, Offloadable {
+    private transient DataDistributionService ddSvc;
+
+    private static final long serialVersionUID = 1L;
+
+    private IMap<DocumentKey, Document> xddCache;
+    private Transaction tx;
+
+    public DocumentRemoveProcessor(IMap<DocumentKey, Document> xddCache, Transaction tx) {
+        this.xddCache = xddCache;
+        this.tx = tx;
+    }
+
+    @Autowired
+    public void setDistrService(DataDistributionService ddSvc) {
+        this.ddSvc = ddSvc;
+    }
+
+    @Override
+    public void processBackup(Map.Entry<DocumentKey, Document> entry) {
+
+    }
+
+    @Override
+    public Object process(Map.Entry<DocumentKey, Document> entry) {
+        Document doc = entry.getValue();
+        DocumentKey lastKey = ddSvc.getLastKeyForUri(doc.getUri());
+        long txStart = tx == null ? TX_NO : tx.getTxId();
+        if (txStart > TX_NO && tx.getTxIsolation().ordinal() > TransactionIsolation.readCommited.ordinal()) {
+            return new BagriException("Document with key: " + entry.getKey() + ", uri: " + doc.getUri() +
+                    " has been concurrently updated; latest key is: " + lastKey, BagriException.ecDocument);
+        }
+
+        doc.finishDocument(txStart);
+        xddCache.set(entry.getKey(), doc);
+        return doc;
+    }
+
+    @Override
+    public EntryBackupProcessor<DocumentKey, Document> getBackupProcessor() {
+        return null;
+    }
+
+    @Override
+    public String getExecutorName() {
+        return Offloadable.NO_OFFLOADING;
+    }
+}

--- a/bagri-server/bagri-server-hazelcast/src/test/java/com/bagri/server/hazelcast/impl/CollectionManagementTest.java
+++ b/bagri-server/bagri-server-hazelcast/src/test/java/com/bagri/server/hazelcast/impl/CollectionManagementTest.java
@@ -139,7 +139,6 @@ public class CollectionManagementTest extends BagriManagementTest {
 		addDocumentsToCollectionTest();
 		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", props);
 		assertEquals(4, ids.size());
-		Properties props = new Properties();
 		props.setProperty(pn_client_fetchSize, "2");
 		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", props);
 		assertEquals(2, ids.size());

--- a/bagri-server/bagri-server-hazelcast/src/test/java/com/bagri/server/hazelcast/impl/CollectionManagementTest.java
+++ b/bagri-server/bagri-server-hazelcast/src/test/java/com/bagri/server/hazelcast/impl/CollectionManagementTest.java
@@ -27,7 +27,7 @@ public class CollectionManagementTest extends BagriManagementTest {
 
     private static ClassPathXmlApplicationContext context;
 
-    private Properties props = null;
+    private Properties props;
     
 	@BeforeClass
 	public static void setUpBeforeClass() throws Exception {
@@ -65,6 +65,8 @@ public class CollectionManagementTest extends BagriManagementTest {
 			xdmRepo.setLibraries(new ArrayList<Library>());
 			xdmRepo.setModules(new ArrayList<Module>());
 		}
+
+		props = new Properties();
 	}
 
 	@After
@@ -79,12 +81,11 @@ public class CollectionManagementTest extends BagriManagementTest {
 	
 	@Test
 	public void addDefaultCollectionDocumentsTest() throws Exception {
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, props);
 		assertEquals(0, ids.size());
-		props = new Properties();
 		//props.setProperty(xdm_document_collections, "CLN_Security");
 		storeSecurityTest();
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", props);
 		assertEquals(4, ids.size());
 		//int cnt = 0;
 		//for (String id: ids) {
@@ -93,21 +94,19 @@ public class CollectionManagementTest extends BagriManagementTest {
 		//	}
 		//}
 		//assertEquals(4, cnt);
-		props = null;
 	}
 
 	@Test
 	public void addCustomCollectionDocumentsTest() throws Exception {
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, props);
 		assertEquals(0, ids.size());
-		props = new Properties();
 		props.setProperty(pn_document_collections, "CLN_Custom");
 		assertEquals(0, uris.size());
 		storeSecurityTest();
 		assertEquals(4, uris.size());
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", props);
 		assertEquals(0, ids.size());
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", props);
 		assertEquals(4, ids.size());
 		int cnt = 0;
 		for (String id: ids) {
@@ -116,17 +115,15 @@ public class CollectionManagementTest extends BagriManagementTest {
 			}
 		}
 		assertEquals(4, cnt);
-		props = null;
 	}
 
 	@Test
 	public void getCollectionDocumentsTest() throws Exception {
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, props);
 		assertEquals(0, ids.size());
-		props = new Properties();
 		props.setProperty(pn_document_collections, "CLN_Security");
 		storeSecurityTest();
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", props);
 		assertEquals(4, ids.size());
 		int cnt = 0;
 		for (String id: ids) {
@@ -135,13 +132,12 @@ public class CollectionManagementTest extends BagriManagementTest {
 			}
 		}
 		assertEquals(4, cnt);
-		props = null;
 	}
 
 	@Test
 	public void limitCollectionDocumentsTest() throws Exception {
 		addDocumentsToCollectionTest();
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", props);
 		assertEquals(4, ids.size());
 		Properties props = new Properties();
 		props.setProperty(pn_client_fetchSize, "2");
@@ -151,22 +147,22 @@ public class CollectionManagementTest extends BagriManagementTest {
 
 	@Test
 	public void addDocumentsToCollectionTest() throws Exception {
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, props);
 		assertEquals(0, ids.size());
 		assertEquals(0, uris.size());
 		storeSecurityTest();
 		assertEquals(4, uris.size());
 		// docs in default collection
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris(null, props);
 		assertEquals(4, ids.size());
 		// the docs are already in CLN_Security collection 
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", props);
 		assertEquals(4, ids.size());
 
 		for (String uri: uris) {
 			this.getDocManagement().addDocumentToCollections(uri, new String[] {"CLN_Custom"});
 		}
-		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", null);
+		ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", props);
 		assertEquals(4, ids.size());
 		int cnt = 0;
 		for (String id: ids) {
@@ -183,7 +179,7 @@ public class CollectionManagementTest extends BagriManagementTest {
 		for (String uri: uris) {
 			this.getDocManagement().removeDocumentFromCollections(uri, new String[] {"CLN_Custom"});
 		}
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Custom), txFinish = 0", props);
 		assertEquals(0, ids.size());
 	}
 
@@ -193,7 +189,7 @@ public class CollectionManagementTest extends BagriManagementTest {
 		assertEquals(4, uris.size());
 		
 		long txId = xRepo.getTxManagement().beginTransaction();
-		Iterable<DocumentAccessor> docs = getDocManagement().removeDocuments("collections.contains(CLN_Security)", null); 
+		Iterable<DocumentAccessor> docs = getDocManagement().removeDocuments("collections.contains(CLN_Security)", props);
 		xRepo.getTxManagement().commitTransaction(txId);
 		int cnt = 0; 
 		for (DocumentAccessor doc: docs) {
@@ -201,7 +197,7 @@ public class CollectionManagementTest extends BagriManagementTest {
 		}
 		assertEquals(4, cnt);
 		
-		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", null);
+		ResultCollection<String> ids = (ResultCollection<String>) this.getDocManagement().getDocumentUris("collections.contains(CLN_Security), txFinish = 0", props);
 		assertEquals(0, ids.size());
 	}
 

--- a/bagri-server/bagri-server-hazelcast/src/test/java/com/bagri/server/hazelcast/impl/DocumentManagementImplTest.java
+++ b/bagri-server/bagri-server-hazelcast/src/test/java/com/bagri/server/hazelcast/impl/DocumentManagementImplTest.java
@@ -3,7 +3,6 @@ package com.bagri.server.hazelcast.impl;
 import com.bagri.core.api.DocumentAccessor;
 import com.bagri.core.api.ResultCollection;
 import com.bagri.core.api.ResultCursor;
-import com.bagri.core.model.Document;
 import com.bagri.core.system.Collection;
 import com.bagri.core.system.Library;
 import com.bagri.core.system.Module;
@@ -17,7 +16,6 @@ import org.junit.BeforeClass;
 import org.junit.Test;
 import org.springframework.context.support.ClassPathXmlApplicationContext;
 
-import java.nio.file.Paths;
 import java.util.ArrayList;
 import java.util.Date;
 import java.util.HashMap;
@@ -26,7 +24,7 @@ import java.util.Properties;
 
 import static com.bagri.core.Constants.*;
 import static com.bagri.core.test.TestUtils.*;
-import static com.bagri.support.util.FileUtils.readTextFile;
+import static com.bagri.support.util.FileUtils.*;
 import static org.junit.Assert.*;
 
 public class DocumentManagementImplTest extends DocumentManagementTest {
@@ -128,7 +126,7 @@ public class DocumentManagementImplTest extends DocumentManagementTest {
 		Properties props = getDocumentProperties();
 		props.setProperty(pn_client_txLevel, pv_client_txLevel_skip);
 		ResultCollection<DocumentAccessor> results = (ResultCollection<DocumentAccessor>) getDocManagement().storeDocuments(docs, props);
-		assertEquals(4, docs.size());
+		assertEquals(4, results.size());
 	}
 
 }


### PR DESCRIPTION
1. Fix tests in bagri-server-hazelcast + remove unused code and imports
2. Remove redundant dependency from bagri-rest
3. Use entry processor for document removal